### PR TITLE
make error() create a PHP warning instead of echo-ing

### DIFF
--- a/instagram.php
+++ b/instagram.php
@@ -130,7 +130,7 @@ class instagramPhp{
      * Error
      */
     public function error($src=''){
-        echo '/!\ error '.$src.'. ';
+        trigger_error( '/!\ error '.$src.'. ', E_USER_WARNING);
     }
 
 }


### PR DESCRIPTION
This is nicer because it allows the error text to be hidden on a live production site in accordance with the server's PHP warning policy.
